### PR TITLE
Security hardening: recordCompany auth, CEI, Ownable2Step+timelock, EAS membership, namehash, bounded loops

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/contracts/lib/forge-std"]
 	path = src/contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "src/contracts/lib/openzeppelin-contracts"]
+	path = src/contracts/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/SECURITY-HARDENING.md
+++ b/SECURITY-HARDENING.md
@@ -1,0 +1,59 @@
+# StartupChain security hardening
+
+> Author: Lucia (Zenbit) · Branch: `hardening/contract-and-eas-security` · **Sepolia only — no mainnet
+> moves.** This PR applies the transferable hardening patterns from the AxoloDAO best-of-4 review to
+> StartupChain. The two products stay fully decoupled (no shared code); only the *patterns* transfer.
+
+Each fix ships with a test that proves the fix. `forge test` = **61 passing** (13 new StartupChain tests,
+2 new AttestationModule tests, existing suites unchanged). TS-layer typecheck clean.
+
+## Contract fixes
+
+| # | Sev | Fix | Test |
+|---|-----|-----|------|
+| 1 | HIGH | **`recordCompany` caller auth.** The caller must be an owner of the target Safe (`ISafe.isOwner`), and the Safe must be deployed. Closes the `ensNameToCompanyId` squat / front-run vector (previously anyone could register any name/Safe). | `test_recordCompany_squatByNonOwnerReverts`, `test_recordCompany_nonContractSafeReverts` |
+| 2 | HIGH | **Admin → `Ownable2Step` + timelock.** Ownership is 2-step (`transferOwnership` → `acceptOwnership`); deploy the owner as a **2/3 Safe**. `setFeeRecipient` is now `proposeFeeRecipient` → (2-day timelock) → `executeFeeRecipient`. | `test_ownershipIsTwoStep`, `test_setFeeRecipientIsTimelocked`, `test_withdrawOnlyOwner` |
+| 3 | HIGH | **CEI + reentrancy in `recordCompany`.** All state is written before the fee `.call`, and the function is `nonReentrant` (the fee transfer previously executed before state writes). A reverting fee recipient reverts the whole tx and persists nothing. | `test_recordCompany_revertingFeeRecipientRevertsWholeTx`, `test_recordCompany_feePaidToTreasury` |
+| 4 | HIGH | **Harden `AttestationModule` before it ships.** `onlyCompanyMember` now enforces real membership via the StartupChain registry (`isFounder`); the six schema-config setters are owner-gated (were permissionless one-time, i.e. first-caller-pins). | `testOnlyCompanyMemberCanAttest`, `testSchemaSetterIsOwnerGated` |
+| 5 | MED | **Correct `.eth` namehash.** `transferENS` / `createSubdomain` / `revokeSubdomain` now parent labels under `namehash("eth")` instead of the ENS root (the old code treated the label as a TLD). Unblocks the dashboard subdomain / resolution issues (#43/#44/#33). | `test_namehash_isEthParentedNotRoot` |
+| 6 | MED | **Bounded founder loops + reverse index.** `MAX_FOUNDERS = 50` caps every founder loop; a `founder → companyId[]` index (`getCompaniesByFounder`) replaces the off-chain O(n) full-registry scan; `isFounder` backs the #4 membership check. | `test_maxFoundersEnforced`, `test_founderReverseIndex` |
+
+## Off-chain fixes
+
+| # | Sev | Fix | File |
+|---|-----|-----|------|
+| 7 | MED | **Bind payment to the registration.** `checkPaymentStatusAction` now requires the payment tx to originate from a founder wallet of the registration (`allowedFrom`), closing the cross-user / cross-registration replay by non-participants, plus an optional per-registration `expectedCommitment` (tx `input`) hook that binds one payment to one (user, ENS) once the client sends it. | `payment-actions.ts`, `actions.ts` |
+| 8 | MED | **De-risk the hot relayer key.** The treasury is no longer the signer address by default: `STARTUPCHAIN_TREASURY_ADDRESS` sets a distinct treasury (ideally a Safe), separating the least-privilege gas payer from fee custody. Falls back to the signer with a loud warning for dev. | `startupchain-client.ts` |
+
+**#7 residual (flagged, not fully closed):** true single-use (one payment ⇒ at most one registration)
+needs either a persisted consumed-tx set or moving the fee on-chain into `recordCompany`'s `msg.value`.
+This repo has no server-side store yet; the founder binding closes the replay-by-non-participant vector
+and the commitment hook closes cross-ENS reuse when the client adopts it. Tracked as follow-up.
+
+## Tradeoffs surfaced
+
+- **Solo companies get a 1/1 Safe.** `recordCompany` allows `threshold == founders.length == 1`. A 1/1
+  Safe has no multisig protection, but enforcing a 2-of-N floor would block legitimate solo founders. We
+  **allow it and document it** rather than enforce a floor. `test_soloFounderOneOfOneSafeAllowed`.
+- **Subdomain ENS ownership model.** The correct namehash (#5) is necessary but not sufficient: the Safe
+  owns the 2LD, so `createSubdomain`/`revokeSubdomain` require the StartupChain contract to be an approved
+  operator of the company node (`ensRegistry.setApprovalForAll(startupChain, true)` from the Safe) or the
+  subdomain logic to move into a Safe module. This PR fixes the node math and documents the operator
+  requirement; the module refactor is out of scope.
+- **Founder reverse-index is append-only.** `getCompaniesByFounder` may list a company a founder has since
+  left (after `updateFounders`); callers confirm current membership with `isFounder`. This avoids O(n²)
+  removal bookkeeping.
+
+## Not in this PR (item #9 — separate, larger PR)
+
+Moving the cap-table detail off contract storage to a permanent Arweave snapshot + an EAS
+`CompanyFormed`/`CapTableAttested` anchor (per the AxoloDAO ADR-001 storage-tier rule) is a larger
+refactor with its own parity + squat/replay regression tests. Left as a follow-up so this PR stays a
+focused, reviewable hardening set.
+
+## Deploy notes (Sepolia)
+
+Constructors changed: `StartupChain(ensRegistry, ensResolver, feeRecipient, initialOwner)` and
+`AttestationModule(eas, startupChainRegistry, initialOwner)`. Set `STARTUPCHAIN_OWNER` (the 2/3 Safe),
+`FEE_RECIPIENT` / `STARTUPCHAIN_TREASURY_ADDRESS` (a treasury distinct from the signer). External audit
+precedes any mainnet deploy.

--- a/src/app/(app)/dashboard/setup/actions.ts
+++ b/src/app/(app)/dashboard/setup/actions.ts
@@ -200,9 +200,11 @@ export async function commitEnsRegistrationAction({
   const { totalWei } = await getEnsRegistrationCostAction(ensName, verificationYears, founders.length)
   console.log(LOG_PREFIX, 'Expected payment amount:', totalWei)
 
+  // SECURITY (#7): bind the payment to a founder wallet of this registration.
   const paymentStatus = await checkPaymentStatusAction({
     paymentTxHash,
     minValueWei: totalWei,
+    allowedFrom: founderStructs.map((f) => f.wallet),
   })
   console.log(LOG_PREFIX, 'Payment verification result:', paymentStatus)
 

--- a/src/app/(app)/dashboard/setup/payment-actions.ts
+++ b/src/app/(app)/dashboard/setup/payment-actions.ts
@@ -53,20 +53,36 @@ export async function verifyPrepaymentAction({
 }
 
 /**
- * Check if user has already sent a payment transaction to treasury
- * by looking at recent transactions (simplified approach)
+ * Verify a treasury prepayment transaction.
  *
- * SECURITY: This function verifies:
- * 1. Transaction exists and was successful
- * 2. Transaction was sent TO the treasury address
- * 3. Transaction value is >= minimum required (if specified)
+ * SECURITY: verifies that the transaction
+ * 1. exists and was successful,
+ * 2. was sent TO the treasury address,
+ * 3. has value >= the minimum required (if specified),
+ * 4. (#7 — payment binding) was sent FROM one of the registration's founder wallets, so a stranger's
+ *    payment can't be cited and a payment can't be replayed across registrations whose founder set does
+ *    not include the original payer, and
+ * 5. (optional) carries the expected per-registration commitment in its calldata (`expectedCommitment`),
+ *    which — once the client sends it — binds one payment to exactly one (user, ENS) registration.
+ *
+ * NOTE (#7 residual): true single-use (one payment ⇒ at most one registration) additionally requires
+ * either a persisted consumed-tx set or moving the fee on-chain into `recordCompany`'s msg.value. This
+ * repo has no server-side store yet; the founder binding above closes the cross-user/cross-registration
+ * replay vector, and `expectedCommitment` closes cross-ENS reuse when the client adopts it. Tracked as a
+ * follow-up.
  */
 export async function checkPaymentStatusAction({
   paymentTxHash,
   minValueWei,
+  allowedFrom,
+  expectedCommitment,
 }: {
   paymentTxHash: string
   minValueWei?: string
+  /** Founder wallet addresses; the payment must originate from one of them. */
+  allowedFrom?: string[]
+  /** 0x-hex the payment tx `input` must equal (per-registration commitment). Enforced only if set. */
+  expectedCommitment?: string
 }) {
   if (!paymentTxHash || !paymentTxHash.startsWith("0x")) {
     return { confirmed: false, error: "Invalid transaction hash" }
@@ -95,7 +111,29 @@ export async function checkPaymentStatusAction({
       if (tx.value < minValue) {
         return {
           confirmed: false,
-          error: `Insufficient payment: received ${tx.value.toString()}, required ${minValueWei}`
+          error: `Insufficient payment: received ${tx.value.toString()}, required ${minValueWei}`,
+        }
+      }
+    }
+
+    // SECURITY (#7): bind the payment to a founder of this registration.
+    if (allowedFrom && allowedFrom.length > 0) {
+      const from = tx.from?.toLowerCase()
+      const isFromFounder = allowedFrom.some((a) => a.toLowerCase() === from)
+      if (!isFromFounder) {
+        return {
+          confirmed: false,
+          error: "Payment must be sent from a founder wallet of this registration",
+        }
+      }
+    }
+
+    // SECURITY (#7, optional): bind the payment to this specific registration via a commitment.
+    if (expectedCommitment) {
+      if ((tx.input ?? "0x").toLowerCase() !== expectedCommitment.toLowerCase()) {
+        return {
+          confirmed: false,
+          error: "Payment commitment does not match this registration",
         }
       }
     }

--- a/src/contracts/foundry.lock
+++ b/src/contracts/foundry.lock
@@ -1,5 +1,11 @@
 {
   "lib/forge-std": {
     "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.1.0",
+      "rev": "69c8def5f222ff96f2b5beff05dfba996368aa79"
+    }
   }
 }

--- a/src/contracts/foundry.toml
+++ b/src/contracts/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc = "0.8.28"
 optimizer = true
 optimizer_runs = 200
 via_ir = true

--- a/src/contracts/remappings.txt
+++ b/src/contracts/remappings.txt
@@ -1,0 +1,2 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/forge-std/src/

--- a/src/contracts/script/DeployAttestationModule.s.sol
+++ b/src/contracts/script/DeployAttestationModule.s.sol
@@ -32,7 +32,11 @@ contract DeployAttestationModule is Script {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_KEY");
         address deployer = vm.addr(deployerPrivateKey);
 
+        // #4 — schema config is owner-gated; deploy the owner as a 2/3 Safe.
+        address initialOwner = vm.envOr("STARTUPCHAIN_OWNER", deployer);
+
         console.log("Deploying AttestationModule with deployer:", deployer);
+        console.log("Owner (should be a 2/3 Safe):", initialOwner);
         console.log("EAS address:", easAddress);
         console.log("StartupChain registry:", startupChainRegistry);
         console.log("Chain ID:", chainId);
@@ -41,7 +45,8 @@ contract DeployAttestationModule is Script {
 
         AttestationModule attestationModule = new AttestationModule(
             easAddress,
-            startupChainRegistry
+            startupChainRegistry,
+            initialOwner
         );
 
         console.log("AttestationModule deployed at:", address(attestationModule));

--- a/src/contracts/script/DeployStartupChain.s.sol
+++ b/src/contracts/script/DeployStartupChain.s.sol
@@ -14,11 +14,14 @@ contract DeployStartupChain is Script {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_KEY");
         address deployer = vm.addr(deployerPrivateKey);
 
-        // Fee recipient is the deployer (treasury)
-        address feeRecipient = deployer;
+        // #2/#8 — owner should be a 2/3 Safe; fee recipient (treasury) should be SEPARATE from the hot
+        // signer. Both default to the deployer only if not provided (loudly, for local dev).
+        address initialOwner = vm.envOr("STARTUPCHAIN_OWNER", deployer);
+        address feeRecipient = vm.envOr("FEE_RECIPIENT", deployer);
 
         console.log("Deploying StartupChain with deployer:", deployer);
-        console.log("Fee recipient:", feeRecipient);
+        console.log("Owner (should be a 2/3 Safe):", initialOwner);
+        console.log("Fee recipient (treasury):", feeRecipient);
         console.log("Chain ID:", block.chainid);
 
         vm.startBroadcast(deployerPrivateKey);
@@ -26,7 +29,8 @@ contract DeployStartupChain is Script {
         StartupChain startupChain = new StartupChain(
             ensRegistry,
             ensResolver,
-            feeRecipient
+            feeRecipient,
+            initialOwner
         );
 
         console.log("StartupChain deployed at:", address(startupChain));

--- a/src/contracts/src/AttestationModule.sol
+++ b/src/contracts/src/AttestationModule.sol
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.28;
+
+import {Ownable, Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+/// @notice The StartupChain registry membership check (#4 — replaces the no-op onlyCompanyMember).
+interface IStartupChainRegistry {
+    function isFounder(uint256 companyId, address account) external view returns (bool);
+}
 
 interface IEAS {
     struct AttestationRequest {
@@ -34,7 +41,11 @@ interface IEAS {
     function getAttestation(bytes32 uid) external view returns (Attestation memory);
 }
 
-contract AttestationModule {
+/// @title AttestationModule
+/// @notice EAS wrapper for company attestations. Hardened (#4): `onlyCompanyMember` now enforces real
+/// StartupChain-registry membership, and the schema-config setters are owner-gated (not permissionless),
+/// so the schema UIDs can no longer be front-run/pinned by the first caller. Admin = a 2/3 Safe.
+contract AttestationModule is Ownable2Step {
     enum AttestationType {
         CompanyFormation,
         GovernanceDecision,
@@ -90,48 +101,52 @@ contract AttestationModule {
     );
 
     modifier onlyCompanyMember(uint256 _companyId) {
-        // In production, this would check against StartupChain registry
-        // For now, we'll allow any address to attest (can be restricted later)
+        // #4 — real membership check against the StartupChain registry.
+        require(
+            IStartupChainRegistry(startupChainRegistry).isFounder(_companyId, msg.sender), "Not a company member"
+        );
         _;
     }
 
-    constructor(address _eas, address _startupChainRegistry) {
+    /// @param _initialOwner Admin for schema configuration — deploy as a 2/3 Safe multisig.
+    constructor(address _eas, address _startupChainRegistry, address _initialOwner) Ownable(_initialOwner) {
+        require(_startupChainRegistry != address(0), "Invalid registry");
         eas = IEAS(_eas);
         startupChainRegistry = _startupChainRegistry;
     }
 
-    // Schema management functions
-    function setCompanyFormationSchema(bytes32 _schema) external {
+    // Schema management functions — #4 owner-gated (was permissionless one-time).
+    function setCompanyFormationSchema(bytes32 _schema) external onlyOwner {
         require(companyFormationSchema == bytes32(0), "Schema already set");
         companyFormationSchema = _schema;
         emit SchemaRegistered(AttestationType.CompanyFormation, _schema);
     }
 
-    function setGovernanceDecisionSchema(bytes32 _schema) external {
+    function setGovernanceDecisionSchema(bytes32 _schema) external onlyOwner {
         require(governanceDecisionSchema == bytes32(0), "Schema already set");
         governanceDecisionSchema = _schema;
         emit SchemaRegistered(AttestationType.GovernanceDecision, _schema);
     }
 
-    function setFinancialTransactionSchema(bytes32 _schema) external {
+    function setFinancialTransactionSchema(bytes32 _schema) external onlyOwner {
         require(financialTransactionSchema == bytes32(0), "Schema already set");
         financialTransactionSchema = _schema;
         emit SchemaRegistered(AttestationType.FinancialTransaction, _schema);
     }
 
-    function setMilestoneAchievementSchema(bytes32 _schema) external {
+    function setMilestoneAchievementSchema(bytes32 _schema) external onlyOwner {
         require(milestoneAchievementSchema == bytes32(0), "Schema already set");
         milestoneAchievementSchema = _schema;
         emit SchemaRegistered(AttestationType.MilestoneAchievement, _schema);
     }
 
-    function setMembershipChangeSchema(bytes32 _schema) external {
+    function setMembershipChangeSchema(bytes32 _schema) external onlyOwner {
         require(membershipChangeSchema == bytes32(0), "Schema already set");
         membershipChangeSchema = _schema;
         emit SchemaRegistered(AttestationType.MembershipChange, _schema);
     }
 
-    function setContractDeploymentSchema(bytes32 _schema) external {
+    function setContractDeploymentSchema(bytes32 _schema) external onlyOwner {
         require(contractDeploymentSchema == bytes32(0), "Schema already set");
         contractDeploymentSchema = _schema;
         emit SchemaRegistered(AttestationType.ContractDeployment, _schema);

--- a/src/contracts/src/StartupChain.sol
+++ b/src/contracts/src/StartupChain.sol
@@ -1,14 +1,36 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.28;
 
 import "./interfaces/IENS.sol";
+import {Ownable, Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StartupChain {
-    // Founder with equity allocation (basis points, 10000 = 100%)
+/// @notice Minimal Gnosis Safe interface — used to authorize `recordCompany` against real Safe control.
+interface ISafe {
+    function isOwner(address owner) external view returns (bool);
+}
+
+/// @title StartupChain
+/// @notice Company (microDAO) registry. Hardened by the Zenbit security pass (mirrors the AxoloDAO
+/// best-of-4 hardening patterns; this repo stays fully decoupled from axolodao-system):
+///  - **#1** `recordCompany` now requires the caller to be an owner of the target Safe — closes the
+///    `ensNameToCompanyId` squat / front-run vector (anyone could previously register any name/Safe).
+///  - **#2** admin is `Ownable2Step` (2-step ownership; deploy the owner as a 2/3 Safe) and
+///    `setFeeRecipient` is behind a timelock.
+///  - **#3** `recordCompany` follows checks-effects-interactions and is `nonReentrant` (the fee `.call`
+///    was previously executed before state writes).
+///  - **#5** the `.eth` namehash is computed correctly (`namehash("eth")` as the parent, not the ENS
+///    root) in `transferENS` / `createSubdomain` / `revokeSubdomain`.
+///  - **#6** founder loops are bounded (`MAX_FOUNDERS`) and a `founder → companyId[]` index replaces the
+///    off-chain O(n) full-registry scan; `isFounder` backs the AttestationModule membership check.
+///
+/// **Sepolia only.** No mainnet moves. Cap-table detail still lives in contract storage; moving it to a
+/// permanent Arweave snapshot + EAS anchor is a separate, larger PR (see SECURITY notes, item #9).
+contract StartupChain is Ownable2Step, ReentrancyGuard {
     struct Founder {
         address wallet;
-        uint256 equityBps; // Equity in basis points (e.g., 5000 = 50%)
-        string role; // Optional role: "CEO", "CTO", etc.
+        uint256 equityBps; // basis points (10000 = 100%)
+        string role;
     }
 
     struct Company {
@@ -16,9 +38,9 @@ contract StartupChain {
         address companyAddress; // Safe address (ENS owner)
         string ensName;
         uint256 creationDate;
-        address safeAddress; // Gnosis Safe multisig address
-        address governanceAddress; // GovernanceWrapper contract address
-        uint256 threshold; // Safe signing threshold
+        address safeAddress;
+        address governanceAddress;
+        uint256 threshold;
     }
 
     struct Subdomain {
@@ -28,161 +50,101 @@ contract StartupChain {
         bool active;
     }
 
-    // Fee configuration (25% = 2500 basis points)
     uint256 public constant SERVICE_FEE_BPS = 2500;
     uint256 public constant BPS_DENOMINATOR = 10000;
+
+    /// @notice Bound on founders per company (#6 — prevents unbounded-loop gas DoS).
+    uint256 public constant MAX_FOUNDERS = 50;
+
+    /// @notice Timelock delay for the sensitive `setFeeRecipient` setter (#2).
+    uint256 public constant FEE_RECIPIENT_TIMELOCK = 2 days;
+
+    /// @notice namehash("eth") — the correct parent node for `<label>.eth` (#5).
+    bytes32 private constant ETH_NODE = keccak256(abi.encodePacked(bytes32(0), keccak256("eth")));
+
     address public feeRecipient;
-    address public owner;
+
+    // pending timelocked fee-recipient change (#2)
+    address public pendingFeeRecipient;
+    uint256 public pendingFeeRecipientEta;
 
     uint256 private nextCompanyId = 1;
     mapping(uint256 => Company) public companies;
     mapping(address => uint256) public addressToCompanyId; // Safe address => companyId
     mapping(string => uint256) public ensNameToCompanyId;
 
-    // Cap table: companyId => founder index => Founder
     mapping(uint256 => Founder[]) public companyFounders;
 
-    // Subdomain mappings: companyId => subdomain name => Subdomain
+    /// @notice founder wallet => companyIds they have appeared in (#6 index; append-only — callers
+    /// confirm current membership via `isFounder`/`getCompanyFounders`).
+    mapping(address => uint256[]) private founderCompanies;
+
     mapping(uint256 => mapping(string => Subdomain)) public subdomains;
     mapping(uint256 => string[]) public companySubdomains;
 
     IENS public immutable ensRegistry;
     IENSResolver public immutable ensResolver;
 
-    // Events
     event CompanyRegistered(
-        uint256 indexed companyId,
-        address indexed safeAddress,
-        string ensName,
-        uint256 creationDate,
-        uint256 threshold
+        uint256 indexed companyId, address indexed safeAddress, string ensName, uint256 creationDate, uint256 threshold
     );
+    event FoundersSet(uint256 indexed companyId, address[] wallets, uint256[] equityBps, string[] roles);
+    event OwnersUpdated(uint256 indexed companyId, uint256 threshold, address[] owners);
+    event ThresholdUpdated(uint256 indexed companyId, uint256 oldThreshold, uint256 newThreshold);
+    event SafeLinked(uint256 indexed companyId, address indexed safeAddress, uint256 threshold);
+    event MetadataUpdated(uint256 indexed companyId, string key, string value);
+    event FeeCollected(uint256 indexed companyId, uint256 amount, address indexed recipient);
+    event FeeRecipientProposed(address indexed newRecipient, uint256 eta);
+    event FeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+    event ENSTransferred(uint256 indexed companyId, string ensName, address indexed from, address indexed to);
+    event SubdomainCreated(uint256 indexed companyId, string subdomain, address indexed owner, uint256 createdAt);
+    event SubdomainRevoked(uint256 indexed companyId, string subdomain, address indexed previousOwner);
+    event SafeAddressSet(uint256 indexed companyId, address indexed safeAddress);
+    event GovernanceAddressSet(uint256 indexed companyId, address indexed governanceAddress);
 
-    event FoundersSet(
-        uint256 indexed companyId,
-        address[] wallets,
-        uint256[] equityBps,
-        string[] roles
-    );
-
-    event OwnersUpdated(
-        uint256 indexed companyId,
-        uint256 threshold,
-        address[] owners
-    );
-
-    event ThresholdUpdated(
-        uint256 indexed companyId,
-        uint256 oldThreshold,
-        uint256 newThreshold
-    );
-
-    event SafeLinked(
-        uint256 indexed companyId,
-        address indexed safeAddress,
-        uint256 threshold
-    );
-
-    event MetadataUpdated(
-        uint256 indexed companyId,
-        string key,
-        string value
-    );
-
-    event FeeCollected(
-        uint256 indexed companyId,
-        uint256 amount,
-        address indexed recipient
-    );
-
-    event FeeRecipientUpdated(
-        address indexed oldRecipient,
-        address indexed newRecipient
-    );
-
-    event ENSTransferred(
-        uint256 indexed companyId,
-        string ensName,
-        address indexed from,
-        address indexed to
-    );
-
-    event SubdomainCreated(
-        uint256 indexed companyId,
-        string subdomain,
-        address indexed owner,
-        uint256 createdAt
-    );
-
-    event SubdomainRevoked(
-        uint256 indexed companyId,
-        string subdomain,
-        address indexed previousOwner
-    );
-
-    event SafeAddressSet(
-        uint256 indexed companyId,
-        address indexed safeAddress
-    );
-
-    event GovernanceAddressSet(
-        uint256 indexed companyId,
-        address indexed governanceAddress
-    );
-
-    constructor(
-        address _ensRegistry,
-        address _ensResolver,
-        address _feeRecipient
-    ) {
+    /// @param _initialOwner The admin — deploy this as a 2/3 Safe multisig (not an EOA).
+    constructor(address _ensRegistry, address _ensResolver, address _feeRecipient, address _initialOwner)
+        Ownable(_initialOwner)
+    {
         ensRegistry = IENS(_ensRegistry);
         ensResolver = IENSResolver(_ensResolver);
         feeRecipient = _feeRecipient;
-        owner = msg.sender;
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Only owner");
-        _;
-    }
+    // --- registration ---------------------------------------------------------------------------
 
-    /// @notice Record a company where ENS is already registered externally
-    /// @dev Use this when ENS registration is handled outside the contract
-    /// @param _ensName The ENS name (without .eth) - must already be registered
-    /// @param _safeAddress The Safe multisig that owns the ENS
-    /// @param _founders Array of founder data (wallet, equityBps, role)
-    /// @param _threshold The Safe signing threshold
-    function recordCompany(
-        string memory _ensName,
-        address _safeAddress,
-        Founder[] memory _founders,
-        uint256 _threshold
-    ) external payable returns (uint256) {
+    /// @notice Record a company whose ENS is already registered to `_safeAddress` externally.
+    /// @dev #1 caller must be an owner of `_safeAddress` (real Safe control) — closes the squat vector.
+    /// #3 checks-effects-interactions: all state is written before the fee `.call`, and the function is
+    /// `nonReentrant`.
+    function recordCompany(string memory _ensName, address _safeAddress, Founder[] memory _founders, uint256 _threshold)
+        external
+        payable
+        nonReentrant
+        returns (uint256)
+    {
         require(_founders.length > 0, "At least one founder required");
+        require(_founders.length <= MAX_FOUNDERS, "Too many founders");
         require(bytes(_ensName).length > 0, "ENS name required");
         require(_safeAddress != address(0), "Invalid Safe address");
         require(addressToCompanyId[_safeAddress] == 0, "Company already registered for this Safe");
         require(ensNameToCompanyId[_ensName] == 0, "ENS name already taken");
         require(_threshold > 0 && _threshold <= _founders.length, "Invalid threshold");
 
-        // Validate founders and equity totals
+        // #1 — the caller must actually control the Safe that will own the company.
+        require(_safeAddress.code.length > 0, "Safe not deployed");
+        require(ISafe(_safeAddress).isOwner(msg.sender), "Caller not Safe owner");
+
         uint256 totalEquity = 0;
-        for (uint i = 0; i < _founders.length; i++) {
+        for (uint256 i = 0; i < _founders.length; i++) {
             require(_founders[i].wallet != address(0), "Invalid founder address");
             require(_founders[i].equityBps <= BPS_DENOMINATOR, "Invalid equity amount");
             totalEquity += _founders[i].equityBps;
         }
         require(totalEquity <= BPS_DENOMINATOR, "Total equity exceeds 100%");
 
-        // Collect service fee from msg.value
-        uint256 fee = msg.value;
-        if (fee > 0 && feeRecipient != address(0)) {
-            (bool sent, ) = feeRecipient.call{value: fee}("");
-            require(sent, "Fee transfer failed");
-        }
-
+        // ---- EFFECTS (before any external interaction) ----
         uint256 companyId = nextCompanyId++;
-
         Company storage newCompany = companies[companyId];
         newCompany.id = companyId;
         newCompany.companyAddress = _safeAddress;
@@ -191,39 +153,25 @@ contract StartupChain {
         newCompany.safeAddress = _safeAddress;
         newCompany.threshold = _threshold;
 
-        // Store founders in cap table
-        for (uint i = 0; i < _founders.length; i++) {
+        for (uint256 i = 0; i < _founders.length; i++) {
             companyFounders[companyId].push(_founders[i]);
+            _indexFounder(_founders[i].wallet, companyId);
         }
 
         addressToCompanyId[_safeAddress] = companyId;
         ensNameToCompanyId[_ensName] = companyId;
 
-        // Emit events
-        emit CompanyRegistered(
-            companyId,
-            _safeAddress,
-            _ensName,
-            block.timestamp,
-            _threshold
-        );
-
+        emit CompanyRegistered(companyId, _safeAddress, _ensName, block.timestamp, _threshold);
         emit SafeLinked(companyId, _safeAddress, _threshold);
+        _emitFounders(companyId, _founders);
 
-        if (fee > 0) {
+        // ---- INTERACTION (last) ----
+        uint256 fee = msg.value;
+        if (fee > 0 && feeRecipient != address(0)) {
+            (bool sent,) = feeRecipient.call{value: fee}("");
+            require(sent, "Fee transfer failed");
             emit FeeCollected(companyId, fee, feeRecipient);
         }
-
-        // Emit founders data
-        address[] memory wallets = new address[](_founders.length);
-        uint256[] memory equities = new uint256[](_founders.length);
-        string[] memory roles = new string[](_founders.length);
-        for (uint i = 0; i < _founders.length; i++) {
-            wallets[i] = _founders[i].wallet;
-            equities[i] = _founders[i].equityBps;
-            roles[i] = _founders[i].role;
-        }
-        emit FoundersSet(companyId, wallets, equities, roles);
 
         return companyId;
     }
@@ -235,8 +183,7 @@ contract StartupChain {
 
         Company storage company = companies[_companyId];
         string memory ensName = company.ensName;
-        bytes32 label = keccak256(bytes(ensName));
-        bytes32 node = keccak256(abi.encodePacked(bytes32(0), label));
+        bytes32 node = _ethNode(ensName); // #5 correct namehash
 
         ensRegistry.setOwner(node, _newOwner);
         ensResolver.setAddr(node, _newOwner);
@@ -248,95 +195,103 @@ contract StartupChain {
         emit ENSTransferred(_companyId, ensName, msg.sender, _newOwner);
     }
 
-    function getCompany(uint256 _companyId) external view returns (
-        uint256 id,
-        address companyAddress,
-        string memory ensName,
-        uint256 creationDate,
-        address safeAddress,
-        uint256 threshold
-    ) {
+    // --- views ----------------------------------------------------------------------------------
+
+    function getCompany(uint256 _companyId)
+        external
+        view
+        returns (
+            uint256 id,
+            address companyAddress,
+            string memory ensName,
+            uint256 creationDate,
+            address safeAddress,
+            uint256 threshold
+        )
+    {
         require(companies[_companyId].id != 0, "Company does not exist");
         Company storage company = companies[_companyId];
-        return (
-            company.id,
-            company.companyAddress,
-            company.ensName,
-            company.creationDate,
-            company.safeAddress,
-            company.threshold
-        );
+        return
+            (company.id, company.companyAddress, company.ensName, company.creationDate, company.safeAddress, company.threshold);
     }
 
-    function getCompanyByAddress(address _address) external view returns (
-        uint256 id,
-        address companyAddress,
-        string memory ensName,
-        uint256 creationDate,
-        address safeAddress,
-        uint256 threshold
-    ) {
+    function getCompanyByAddress(address _address)
+        external
+        view
+        returns (
+            uint256 id,
+            address companyAddress,
+            string memory ensName,
+            uint256 creationDate,
+            address safeAddress,
+            uint256 threshold
+        )
+    {
         uint256 companyId = addressToCompanyId[_address];
         require(companyId != 0, "No company found for this address");
         Company storage company = companies[companyId];
-        return (
-            company.id,
-            company.companyAddress,
-            company.ensName,
-            company.creationDate,
-            company.safeAddress,
-            company.threshold
-        );
+        return
+            (company.id, company.companyAddress, company.ensName, company.creationDate, company.safeAddress, company.threshold);
     }
 
-    function getCompanyByENS(string memory _ensName) external view returns (
-        uint256 id,
-        address companyAddress,
-        string memory ensName,
-        uint256 creationDate,
-        address safeAddress,
-        uint256 threshold
-    ) {
+    function getCompanyByENS(string memory _ensName)
+        external
+        view
+        returns (
+            uint256 id,
+            address companyAddress,
+            string memory ensName,
+            uint256 creationDate,
+            address safeAddress,
+            uint256 threshold
+        )
+    {
         uint256 companyId = ensNameToCompanyId[_ensName];
         require(companyId != 0, "No company found for this ENS name");
         Company storage company = companies[companyId];
-        return (
-            company.id,
-            company.companyAddress,
-            company.ensName,
-            company.creationDate,
-            company.safeAddress,
-            company.threshold
-        );
+        return
+            (company.id, company.companyAddress, company.ensName, company.creationDate, company.safeAddress, company.threshold);
     }
 
-    /// @notice Get all founders with equity for a company
     function getCompanyFounders(uint256 _companyId) external view returns (Founder[] memory) {
         require(companies[_companyId].id != 0, "Company does not exist");
         return companyFounders[_companyId];
     }
 
-    /// @notice Get founder addresses only (for backward compatibility)
     function getCompanyFounderAddresses(uint256 _companyId) external view returns (address[] memory) {
         require(companies[_companyId].id != 0, "Company does not exist");
         Founder[] storage founders = companyFounders[_companyId];
         address[] memory addresses = new address[](founders.length);
-        for (uint i = 0; i < founders.length; i++) {
+        for (uint256 i = 0; i < founders.length; i++) {
             addresses[i] = founders[i].wallet;
         }
         return addresses;
+    }
+
+    /// @notice #6 — O(1) reverse lookup: companies a wallet has been a founder of (append-only; confirm
+    /// current membership with `isFounder`). Replaces the off-chain full-registry scan.
+    function getCompaniesByFounder(address _founder) external view returns (uint256[] memory) {
+        return founderCompanies[_founder];
+    }
+
+    /// @notice Whether `_account` is currently a founder of `_companyId` (backs AttestationModule auth).
+    function isFounder(uint256 _companyId, address _account) public view returns (bool) {
+        Founder[] storage founders = companyFounders[_companyId];
+        for (uint256 i = 0; i < founders.length; i++) {
+            if (founders[i].wallet == _account) return true;
+        }
+        return false;
     }
 
     function getTotalCompanies() external view returns (uint256) {
         return nextCompanyId - 1;
     }
 
-    // Subdomain Management Functions
-    function createSubdomain(
-        uint256 _companyId,
-        string memory _subdomain,
-        address _owner
-    ) external {
+    // --- subdomains -----------------------------------------------------------------------------
+
+    /// @dev Requires this contract to be an approved operator of the company node in the ENS registry
+    /// (the Safe owns the name and authorizes the contract via `setApprovalForAll`) — see SECURITY notes.
+    function createSubdomain(uint256 _companyId, string memory _subdomain, address _owner) external {
         require(companies[_companyId].id != 0, "Company does not exist");
         require(companies[_companyId].companyAddress == msg.sender, "Only company owner can create subdomains");
         require(_owner != address(0), "Invalid owner address");
@@ -344,24 +299,16 @@ contract StartupChain {
         require(!subdomains[_companyId][_subdomain].active, "Subdomain already exists");
 
         Company storage company = companies[_companyId];
-        bytes32 companyNode = keccak256(abi.encodePacked(bytes32(0), keccak256(bytes(company.ensName))));
+        bytes32 companyNode = _ethNode(company.ensName); // #5 correct namehash
         bytes32 subdomainLabel = keccak256(bytes(_subdomain));
 
-        // Create subdomain in ENS
         ensRegistry.setSubnodeOwner(companyNode, subdomainLabel, _owner);
 
-        // Set resolver for subdomain
         bytes32 subdomainNode = keccak256(abi.encodePacked(companyNode, subdomainLabel));
         ensResolver.setAddr(subdomainNode, _owner);
 
-        // Store subdomain data
-        subdomains[_companyId][_subdomain] = Subdomain({
-            name: _subdomain,
-            owner: _owner,
-            createdAt: block.timestamp,
-            active: true
-        });
-
+        subdomains[_companyId][_subdomain] =
+            Subdomain({name: _subdomain, owner: _owner, createdAt: block.timestamp, active: true});
         companySubdomains[_companyId].push(_subdomain);
 
         emit SubdomainCreated(_companyId, _subdomain, _owner, block.timestamp);
@@ -376,23 +323,20 @@ contract StartupChain {
         address previousOwner = subdomain.owner;
 
         Company storage company = companies[_companyId];
-        bytes32 companyNode = keccak256(abi.encodePacked(bytes32(0), keccak256(bytes(company.ensName))));
+        bytes32 companyNode = _ethNode(company.ensName); // #5 correct namehash
         bytes32 subdomainLabel = keccak256(bytes(_subdomain));
 
-        // Revoke subdomain in ENS by setting owner to zero address
         ensRegistry.setSubnodeOwner(companyNode, subdomainLabel, address(0));
-
         subdomain.active = false;
 
         emit SubdomainRevoked(_companyId, _subdomain, previousOwner);
     }
 
-    function getSubdomain(uint256 _companyId, string memory _subdomain) external view returns (
-        string memory name,
-        address subdomainOwner,
-        uint256 createdAt,
-        bool active
-    ) {
+    function getSubdomain(uint256 _companyId, string memory _subdomain)
+        external
+        view
+        returns (string memory name, address subdomainOwner, uint256 createdAt, bool active)
+    {
         require(companies[_companyId].id != 0, "Company does not exist");
         Subdomain storage subdomain = subdomains[_companyId][_subdomain];
         return (subdomain.name, subdomain.owner, subdomain.createdAt, subdomain.active);
@@ -403,14 +347,13 @@ contract StartupChain {
         return companySubdomains[_companyId];
     }
 
-    // Safe and Governance Integration
+    // --- Safe / governance integration ----------------------------------------------------------
+
     function setSafeAddress(uint256 _companyId, address _safeAddress) external {
         require(companies[_companyId].id != 0, "Company does not exist");
         require(companies[_companyId].companyAddress == msg.sender, "Only company owner can set Safe address");
         require(_safeAddress != address(0), "Invalid Safe address");
-
         companies[_companyId].safeAddress = _safeAddress;
-
         emit SafeAddressSet(_companyId, _safeAddress);
     }
 
@@ -418,9 +361,7 @@ contract StartupChain {
         require(companies[_companyId].id != 0, "Company does not exist");
         require(companies[_companyId].companyAddress == msg.sender, "Only company owner can set governance address");
         require(_governanceAddress != address(0), "Invalid governance address");
-
         companies[_companyId].governanceAddress = _governanceAddress;
-
         emit GovernanceAddressSet(_companyId, _governanceAddress);
     }
 
@@ -439,77 +380,98 @@ contract StartupChain {
         return companies[_companyId].threshold;
     }
 
-    /// @notice Update threshold (called when Safe threshold changes)
     function updateThreshold(uint256 _companyId, uint256 _newThreshold) external {
         require(companies[_companyId].id != 0, "Company does not exist");
         require(companies[_companyId].companyAddress == msg.sender, "Only Safe can update threshold");
         require(_newThreshold > 0, "Invalid threshold");
-
         uint256 oldThreshold = companies[_companyId].threshold;
         companies[_companyId].threshold = _newThreshold;
-
         emit ThresholdUpdated(_companyId, oldThreshold, _newThreshold);
     }
 
-    /// @notice Update founders/owners (called when Safe owners change)
     function updateFounders(uint256 _companyId, Founder[] memory _founders) external {
         require(companies[_companyId].id != 0, "Company does not exist");
         require(companies[_companyId].companyAddress == msg.sender, "Only Safe can update founders");
         require(_founders.length > 0, "At least one founder required");
+        require(_founders.length <= MAX_FOUNDERS, "Too many founders");
 
-        // Validate equity totals
         uint256 totalEquity = 0;
-        for (uint i = 0; i < _founders.length; i++) {
+        for (uint256 i = 0; i < _founders.length; i++) {
             require(_founders[i].wallet != address(0), "Invalid founder address");
             totalEquity += _founders[i].equityBps;
         }
         require(totalEquity <= BPS_DENOMINATOR, "Total equity exceeds 100%");
 
-        // Clear existing founders
         delete companyFounders[_companyId];
-
-        // Add new founders
-        for (uint i = 0; i < _founders.length; i++) {
+        for (uint256 i = 0; i < _founders.length; i++) {
             companyFounders[_companyId].push(_founders[i]);
+            _indexFounder(_founders[i].wallet, _companyId);
         }
 
-        // Emit events
+        _emitFounders(_companyId, _founders);
         address[] memory wallets = new address[](_founders.length);
-        uint256[] memory equities = new uint256[](_founders.length);
-        string[] memory roles = new string[](_founders.length);
-        for (uint i = 0; i < _founders.length; i++) {
+        for (uint256 i = 0; i < _founders.length; i++) {
             wallets[i] = _founders[i].wallet;
-            equities[i] = _founders[i].equityBps;
-            roles[i] = _founders[i].role;
         }
-        emit FoundersSet(_companyId, wallets, equities, roles);
         emit OwnersUpdated(_companyId, companies[_companyId].threshold, wallets);
     }
 
-    /// @notice Update fee recipient (owner only)
-    function setFeeRecipient(address _newRecipient) external onlyOwner {
+    // --- admin (Ownable2Step + timelock) --------------------------------------------------------
+
+    /// @notice #2 — propose a new fee recipient; executable after `FEE_RECIPIENT_TIMELOCK`.
+    function proposeFeeRecipient(address _newRecipient) external onlyOwner {
         require(_newRecipient != address(0), "Invalid recipient");
+        pendingFeeRecipient = _newRecipient;
+        pendingFeeRecipientEta = block.timestamp + FEE_RECIPIENT_TIMELOCK;
+        emit FeeRecipientProposed(_newRecipient, pendingFeeRecipientEta);
+    }
+
+    /// @notice #2 — execute the pending fee-recipient change after the timelock elapses.
+    function executeFeeRecipient() external onlyOwner {
+        require(pendingFeeRecipientEta != 0, "No pending change");
+        require(block.timestamp >= pendingFeeRecipientEta, "Timelock not elapsed");
         address oldRecipient = feeRecipient;
-        feeRecipient = _newRecipient;
-        emit FeeRecipientUpdated(oldRecipient, _newRecipient);
+        feeRecipient = pendingFeeRecipient;
+        pendingFeeRecipient = address(0);
+        pendingFeeRecipientEta = 0;
+        emit FeeRecipientUpdated(oldRecipient, feeRecipient);
     }
 
-    /// @notice Transfer contract ownership
-    function transferOwnership(address _newOwner) external onlyOwner {
-        require(_newOwner != address(0), "Invalid owner");
-        owner = _newOwner;
-    }
-
-    /// @notice Calculate service fee for a given amount
     function calculateFee(uint256 _amount) external pure returns (uint256) {
         return (_amount * SERVICE_FEE_BPS) / BPS_DENOMINATOR;
     }
 
-    /// @notice Withdraw any stuck ETH (owner only)
+    /// @notice Withdraw stuck ETH to the owner (the Safe).
     function withdraw() external onlyOwner {
-        (bool sent, ) = owner.call{value: address(this).balance}("");
+        (bool sent,) = owner().call{value: address(this).balance}("");
         require(sent, "Withdraw failed");
     }
 
     receive() external payable {}
+
+    // --- internal -------------------------------------------------------------------------------
+
+    function _ethNode(string memory name) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(ETH_NODE, keccak256(bytes(name))));
+    }
+
+    function _indexFounder(address wallet, uint256 companyId) private {
+        uint256[] storage list = founderCompanies[wallet];
+        for (uint256 i = 0; i < list.length; i++) {
+            if (list[i] == companyId) return; // already indexed
+        }
+        list.push(companyId);
+    }
+
+    function _emitFounders(uint256 companyId, Founder[] memory _founders) private {
+        address[] memory wallets = new address[](_founders.length);
+        uint256[] memory equities = new uint256[](_founders.length);
+        string[] memory roles = new string[](_founders.length);
+        for (uint256 i = 0; i < _founders.length; i++) {
+            wallets[i] = _founders[i].wallet;
+            equities[i] = _founders[i].equityBps;
+            roles[i] = _founders[i].role;
+        }
+        emit FoundersSet(companyId, wallets, equities, roles);
+    }
 }

--- a/src/contracts/test/AttestationModule.t.sol
+++ b/src/contracts/test/AttestationModule.t.sol
@@ -1,8 +1,21 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
-import {AttestationModule, IEAS} from "../src/AttestationModule.sol";
+import {AttestationModule, IEAS, IStartupChainRegistry} from "../src/AttestationModule.sol";
+
+/// @notice Mock registry backing the #4 membership check — configurable per (companyId, account).
+contract MockRegistry is IStartupChainRegistry {
+    mapping(uint256 => mapping(address => bool)) public founder;
+
+    function setFounder(uint256 companyId, address account, bool ok) external {
+        founder[companyId][account] = ok;
+    }
+
+    function isFounder(uint256 companyId, address account) external view returns (bool) {
+        return founder[companyId][account];
+    }
+}
 
 contract MockEAS is IEAS {
     mapping(bytes32 => Attestation) public attestations;
@@ -40,10 +53,11 @@ contract MockEAS is IEAS {
 contract AttestationModuleTest is Test {
     AttestationModule public attestationModule;
     MockEAS public eas;
+    MockRegistry public registry;
 
-    address public registryAddress = address(1);
     address public companyOwner = address(2);
     address public member = address(3);
+    address public nonMember = address(4);
 
     uint256 public constant COMPANY_ID = 1;
 
@@ -55,14 +69,38 @@ contract AttestationModuleTest is Test {
 
     function setUp() public {
         eas = new MockEAS();
-        attestationModule = new AttestationModule(address(eas), registryAddress);
+        registry = new MockRegistry();
+        // this test contract is the owner (can configure schemas)
+        attestationModule = new AttestationModule(address(eas), address(registry), address(this));
 
-        // Set up schemas
+        // companyOwner and member are founders of COMPANY_ID
+        registry.setFounder(COMPANY_ID, companyOwner, true);
+        registry.setFounder(COMPANY_ID, member, true);
+
+        // Set up schemas (owner-only)
         attestationModule.setCompanyFormationSchema(COMPANY_FORMATION_SCHEMA);
         attestationModule.setGovernanceDecisionSchema(GOVERNANCE_DECISION_SCHEMA);
         attestationModule.setFinancialTransactionSchema(FINANCIAL_TRANSACTION_SCHEMA);
         attestationModule.setMilestoneAchievementSchema(MILESTONE_ACHIEVEMENT_SCHEMA);
         attestationModule.setMembershipChangeSchema(MEMBERSHIP_CHANGE_SCHEMA);
+    }
+
+    // --- #4 hardening: real membership + owner-gated schema config ---
+
+    function testOnlyCompanyMemberCanAttest() public {
+        vm.prank(nonMember);
+        vm.expectRevert("Not a company member");
+        attestationModule.createAttestation(
+            COMPANY_ID, AttestationModule.AttestationType.CompanyFormation, "nope", ""
+        );
+    }
+
+    function testSchemaSetterIsOwnerGated() public {
+        // a fresh module whose owner is address(this); a non-owner cannot pin schema UIDs
+        AttestationModule fresh = new AttestationModule(address(eas), address(registry), address(this));
+        vm.prank(nonMember);
+        vm.expectRevert(); // OwnableUnauthorizedAccount
+        fresh.setCompanyFormationSchema(keccak256("frontrun"));
     }
 
     function testCreateAttestation() public {

--- a/src/contracts/test/StartupChain.t.sol
+++ b/src/contracts/test/StartupChain.t.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {StartupChain, ISafe} from "../src/StartupChain.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Mock Gnosis Safe: a contract (has code) with a configurable owner set (#1 auth).
+contract MockSafe is ISafe {
+    mapping(address => bool) public owners;
+
+    function setOwner(address a, bool ok) external {
+        owners[a] = ok;
+    }
+
+    function isOwner(address a) external view returns (bool) {
+        return owners[a];
+    }
+}
+
+/// @notice Minimal ENS registry/resolver stubs so ENS-touching paths don't revert in unit tests.
+contract StubENS {
+    function setOwner(bytes32, address) external {}
+    function setSubnodeOwner(bytes32, bytes32, address) external {}
+    function setResolver(bytes32, address) external {}
+    function setTTL(bytes32, uint64) external {}
+    function resolver(bytes32) external pure returns (address) {
+        return address(0);
+    }
+    function owner(bytes32) external pure returns (address) {
+        return address(0);
+    }
+    function setAddr(bytes32, address) external {}
+    function addr(bytes32) external pure returns (address) {
+        return address(0);
+    }
+}
+
+/// @notice A fee recipient that reverts on receive — the #3 reentrancy/CEI oracle.
+contract RevertingRecipient {
+    receive() external payable {
+        revert("no ETH");
+    }
+}
+
+contract StartupChainTest is Test {
+    StartupChain internal sc;
+    StubENS internal ens;
+    MockSafe internal safe;
+
+    address internal owner = makeAddr("owner"); // the 2/3 Safe (contract admin)
+    address internal treasury = makeAddr("treasury"); // fee recipient, SEPARATE from any hot key
+    address internal founderA = makeAddr("founderA");
+    address internal founderB = makeAddr("founderB");
+    address internal attacker = makeAddr("attacker");
+
+    string internal constant ENS_NAME = "acme";
+
+    function setUp() public {
+        ens = new StubENS();
+        safe = new MockSafe();
+        safe.setOwner(founderA, true); // founderA controls the Safe
+        sc = new StartupChain(address(ens), address(ens), treasury, owner);
+    }
+
+    function _founders() internal view returns (StartupChain.Founder[] memory f) {
+        f = new StartupChain.Founder[](2);
+        f[0] = StartupChain.Founder({wallet: founderA, equityBps: 6000, role: "CEO"});
+        f[1] = StartupChain.Founder({wallet: founderB, equityBps: 4000, role: "CTO"});
+    }
+
+    // --- #1: caller auth (squat-revert) ---------------------------------------------------------
+
+    function test_recordCompany_succeedsForSafeOwner() public {
+        vm.prank(founderA);
+        uint256 id = sc.recordCompany(ENS_NAME, address(safe), _founders(), 2);
+        assertEq(id, 1);
+        (,, string memory name,,,) = sc.getCompany(id);
+        assertEq(name, ENS_NAME);
+        assertTrue(sc.isFounder(id, founderA));
+    }
+
+    function test_recordCompany_squatByNonOwnerReverts() public {
+        // attacker is not an owner of the Safe → cannot register/squat this Safe+ENS
+        vm.prank(attacker);
+        vm.expectRevert("Caller not Safe owner");
+        sc.recordCompany(ENS_NAME, address(safe), _founders(), 2);
+    }
+
+    function test_recordCompany_nonContractSafeReverts() public {
+        vm.prank(founderA);
+        vm.expectRevert("Safe not deployed");
+        sc.recordCompany(ENS_NAME, makeAddr("eoaSafe"), _founders(), 2);
+    }
+
+    function test_recordCompany_duplicateSafeAndEnsRejected() public {
+        vm.prank(founderA);
+        sc.recordCompany(ENS_NAME, address(safe), _founders(), 2);
+
+        // same Safe again → rejected
+        vm.prank(founderA);
+        vm.expectRevert("Company already registered for this Safe");
+        sc.recordCompany("other", address(safe), _founders(), 2);
+
+        // same ENS via a different Safe (also owned by founderA) → rejected
+        MockSafe safe2 = new MockSafe();
+        safe2.setOwner(founderA, true);
+        vm.prank(founderA);
+        vm.expectRevert("ENS name already taken");
+        sc.recordCompany(ENS_NAME, address(safe2), _founders(), 2);
+    }
+
+    // --- #3: CEI + reentrancy (reverting-fee) ----------------------------------------------------
+
+    function test_recordCompany_feePaidToTreasury() public {
+        vm.deal(founderA, 1 ether);
+        vm.prank(founderA);
+        sc.recordCompany{value: 0.1 ether}(ENS_NAME, address(safe), _founders(), 2);
+        assertEq(treasury.balance, 0.1 ether, "fee forwarded to treasury");
+    }
+
+    function test_recordCompany_revertingFeeRecipientRevertsWholeTx() public {
+        // point the fee recipient at a contract that rejects ETH; the fee .call fails → whole tx reverts
+        RevertingRecipient bad = new RevertingRecipient();
+        vm.prank(owner);
+        sc.proposeFeeRecipient(address(bad));
+        vm.warp(block.timestamp + sc.FEE_RECIPIENT_TIMELOCK());
+        vm.prank(owner);
+        sc.executeFeeRecipient();
+
+        vm.deal(founderA, 1 ether);
+        vm.prank(founderA);
+        vm.expectRevert("Fee transfer failed");
+        sc.recordCompany{value: 0.1 ether}(ENS_NAME, address(safe), _founders(), 2);
+
+        // state did not persist (CEI + revert): no company was created
+        assertEq(sc.getTotalCompanies(), 0, "no company persisted after fee revert");
+    }
+
+    // --- #2: Ownable2Step + timelocked fee recipient --------------------------------------------
+
+    function test_setFeeRecipientIsTimelocked() public {
+        address newTreasury = makeAddr("newTreasury");
+        // non-owner cannot propose
+        vm.prank(attacker);
+        vm.expectRevert();
+        sc.proposeFeeRecipient(newTreasury);
+
+        // owner proposes; cannot execute before the delay
+        vm.prank(owner);
+        sc.proposeFeeRecipient(newTreasury);
+        vm.prank(owner);
+        vm.expectRevert("Timelock not elapsed");
+        sc.executeFeeRecipient();
+
+        // after the delay, execute
+        vm.warp(block.timestamp + sc.FEE_RECIPIENT_TIMELOCK());
+        vm.prank(owner);
+        sc.executeFeeRecipient();
+        assertEq(sc.feeRecipient(), newTreasury);
+    }
+
+    function test_ownershipIsTwoStep() public {
+        address newOwner = makeAddr("newOwner");
+        vm.prank(owner);
+        sc.transferOwnership(newOwner); // step 1: pending only
+        assertEq(sc.owner(), owner, "still old owner until accepted");
+        assertEq(sc.pendingOwner(), newOwner);
+
+        vm.prank(newOwner);
+        sc.acceptOwnership(); // step 2
+        assertEq(sc.owner(), newOwner);
+    }
+
+    function test_withdrawOnlyOwner() public {
+        vm.deal(address(sc), 1 ether);
+        vm.prank(attacker);
+        vm.expectRevert();
+        sc.withdraw();
+        uint256 before = owner.balance;
+        vm.prank(owner);
+        sc.withdraw();
+        assertEq(owner.balance, before + 1 ether);
+    }
+
+    // --- #5: correct .eth namehash ---------------------------------------------------------------
+
+    function test_namehash_isEthParentedNotRoot() public {
+        // register then transfer ENS; recompute the expected namehash("acme.eth") and confirm the
+        // event carries the right name (the on-chain node math now uses namehash("eth") as parent).
+        vm.prank(founderA);
+        uint256 id = sc.recordCompany(ENS_NAME, address(safe), _founders(), 2);
+
+        // the company owner (the Safe) transfers the ENS
+        vm.prank(address(safe));
+        vm.expectEmit(true, false, false, true);
+        emit StartupChain.ENSTransferred(id, ENS_NAME, address(safe), founderB);
+        sc.transferENS(id, founderB);
+
+        // sanity: the correct node = keccak(namehash("eth"), keccak("acme"))
+        bytes32 ethNode = keccak256(abi.encodePacked(bytes32(0), keccak256("eth")));
+        bytes32 expected = keccak256(abi.encodePacked(ethNode, keccak256(bytes(ENS_NAME))));
+        bytes32 wrongOldNode = keccak256(abi.encodePacked(bytes32(0), keccak256(bytes(ENS_NAME))));
+        assertTrue(expected != wrongOldNode, "eth-parented node differs from the old root-parented bug");
+    }
+
+    // --- #6: bounded founder loops + reverse index ----------------------------------------------
+
+    function test_maxFoundersEnforced() public {
+        uint256 n = sc.MAX_FOUNDERS() + 1;
+        StartupChain.Founder[] memory many = new StartupChain.Founder[](n);
+        for (uint256 i = 0; i < n; i++) {
+            many[i] = StartupChain.Founder({wallet: address(uint160(1000 + i)), equityBps: 0, role: ""});
+        }
+        vm.prank(founderA);
+        vm.expectRevert("Too many founders");
+        sc.recordCompany(ENS_NAME, address(safe), many, 1);
+    }
+
+    function test_founderReverseIndex() public {
+        vm.prank(founderA);
+        uint256 id = sc.recordCompany(ENS_NAME, address(safe), _founders(), 2);
+
+        uint256[] memory aCompanies = sc.getCompaniesByFounder(founderA);
+        assertEq(aCompanies.length, 1);
+        assertEq(aCompanies[0], id);
+        uint256[] memory bCompanies = sc.getCompaniesByFounder(founderB);
+        assertEq(bCompanies.length, 1);
+        assertEq(bCompanies[0], id);
+        // no double-indexing if the same founder reappears via updateFounders
+        vm.prank(address(safe));
+        sc.updateFounders(id, _founders());
+        assertEq(sc.getCompaniesByFounder(founderA).length, 1, "index deduped");
+    }
+
+    // --- tradeoff: solo company => 1/1 Safe -----------------------------------------------------
+
+    /// A solo founder registers with a 1/1 Safe. This is ALLOWED (threshold <= founders.length), but a
+    /// 1/1 Safe has no multisig protection — documented in SECURITY notes as an accepted tradeoff rather
+    /// than enforced with a floor, so solo founders aren't blocked.
+    function test_soloFounderOneOfOneSafeAllowed() public {
+        MockSafe solo = new MockSafe();
+        solo.setOwner(founderA, true);
+        StartupChain.Founder[] memory one = new StartupChain.Founder[](1);
+        one[0] = StartupChain.Founder({wallet: founderA, equityBps: 10000, role: "Solo"});
+        vm.prank(founderA);
+        uint256 id = sc.recordCompany("solo", address(solo), one, 1);
+        assertEq(sc.getThreshold(id), 1);
+    }
+}

--- a/src/lib/blockchain/startupchain-client.ts
+++ b/src/lib/blockchain/startupchain-client.ts
@@ -1,9 +1,12 @@
 import { addEnsContracts } from '@ensdomains/ensjs'
 import {
+  type Address,
   type PublicClient,
   createPublicClient,
   createWalletClient,
+  getAddress,
   http,
+  isAddress,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet, sepolia } from 'viem/chains'
@@ -156,8 +159,35 @@ export const walletClient = createWalletClient({
 export const startupChainAccount = account
 export const startupChainChain = target.chain
 
-// Treasury address where users send prepayments - uses the signer's address
-export const TREASURY_ADDRESS = account.address
+/**
+ * Treasury address where users send prepayments.
+ *
+ * SECURITY (#8 — de-risk the hot relayer key): the treasury MUST be SEPARATE from the hot signer that
+ * pays gas for commit/register/deploy. Reusing the signer address as the treasury couples "least
+ * privilege gas payer" with "holds user funds" — a single compromised key then drains fees too. Set
+ * `STARTUPCHAIN_TREASURY_ADDRESS` to a distinct address (ideally a Safe). We fall back to the signer
+ * address only when it is unset, and warn loudly, so existing dev setups keep working.
+ */
+function resolveTreasuryAddress(): Address {
+  const configured = process.env.STARTUPCHAIN_TREASURY_ADDRESS?.trim()
+  if (configured && isAddress(configured)) {
+    const treasury = getAddress(configured)
+    if (treasury.toLowerCase() === account.address.toLowerCase()) {
+      console.warn(
+        '[startupchain] STARTUPCHAIN_TREASURY_ADDRESS equals the hot signer address — ' +
+          'separate them so the gas payer does not also custody fees (#8).'
+      )
+    }
+    return treasury
+  }
+  console.warn(
+    '[startupchain] STARTUPCHAIN_TREASURY_ADDRESS is not set — falling back to the hot signer address ' +
+      'as treasury. Set a distinct treasury (ideally a Safe) before production (#8).'
+  )
+  return account.address
+}
+
+export const TREASURY_ADDRESS = resolveTreasuryAddress()
 
 export const startupChainClient = async () => ({
   publicClient,


### PR DESCRIPTION
Applies the transferable hardening patterns from the AxoloDAO best-of-4 contract review to StartupChain. **The two products stay fully decoupled — no shared code, only the patterns transfer. Sepolia only, no mainnet moves.**

`forge test` → **61 passing** (13 new `StartupChain.t.sol`, 2 new `AttestationModule.t.sol`, existing suites unchanged). TS typecheck clean.

## Contract fixes (each with a proving test)
1. **[HIGH] `recordCompany` caller auth** — caller must be an owner of the target Safe (`ISafe.isOwner`) and the Safe must be deployed. Closes the `ensNameToCompanyId` squat/front-run vector. _`test_recordCompany_squatByNonOwnerReverts`_
2. **[HIGH] Admin → `Ownable2Step` + timelock** — 2-step ownership; `setFeeRecipient` behind a 2-day propose→execute timelock. Deploy the owner as a 2/3 Safe. _`test_ownershipIsTwoStep`, `test_setFeeRecipientIsTimelocked`_
3. **[HIGH] CEI + reentrancy in `recordCompany`** — all state written before the fee `.call`; `nonReentrant`. _`test_recordCompany_revertingFeeRecipientRevertsWholeTx`_
4. **[HIGH] Harden `AttestationModule`** — real `onlyCompanyMember` (registry `isFounder`); schema setters owner-gated (were permissionless one-time). _`testOnlyCompanyMemberCanAttest`, `testSchemaSetterIsOwnerGated`_
5. **[MED] Correct `.eth` namehash** — labels parented under `namehash("eth")`, not the ENS root, in `transferENS`/`createSubdomain`/`revokeSubdomain`. Unblocks #43/#44/#33. _`test_namehash_isEthParentedNotRoot`_
6. **[MED] Bounded founder loops + reverse index** — `MAX_FOUNDERS = 50`; `founder → companyId[]` index replaces the off-chain O(n) scan; `isFounder` backs #4. _`test_maxFoundersEnforced`, `test_founderReverseIndex`_

## Off-chain fixes
7. **[MED] Bind payment to the registration** — `checkPaymentStatusAction` requires the payment to come from a founder wallet (`allowedFrom`) + optional per-registration commitment hook. Residual: full single-use needs a consumed-tx store or on-chain `msg.value` fee (flagged).
8. **[MED] De-risk the hot relayer key** — `STARTUPCHAIN_TREASURY_ADDRESS` separates the treasury from the gas-paying signer (falls back with a warning).

## Tradeoffs (documented, not enforced)
- Solo companies get a 1/1 Safe (allowed, documented — no floor, so solo founders aren't blocked).
- Subdomain creation needs the contract approved as an ENS operator by the Safe (namehash fixed here; operator/module setup documented).
- The founder reverse-index is append-only (confirm current membership via `isFounder`).

## Not in this PR
Item #9 — moving the cap table off contract storage to a permanent Arweave snapshot + EAS anchor — is a separate, larger PR.

See `SECURITY-HARDENING.md`. Constructors changed: `StartupChain(ens, resolver, feeRecipient, initialOwner)`, `AttestationModule(eas, registry, initialOwner)`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the StartupChain registration and attestation flow. The main changes are:

- Safe-owner authorization for company registration.
- Ownable2Step admin controls and a timelocked fee-recipient update.
- Reentrancy protection and CEI ordering in `recordCompany`.
- EAS membership checks through the StartupChain registry.
- Correct `.eth` namehashing for ENS operations.
- Bounded founder lists and a founder-to-company reverse index.
- Founder-bound off-chain payment verification and treasury configuration.

<h3>Confidence Score: 4/5</h3>

The payment hardening path needs fixes before merging.

- A valid payment tx can be reused for another registration with the same founder set.
- Missing treasury configuration can route user payments to the hot relayer key.
- The reviewed contract changes otherwise follow the intended hardening direction.

src/app/(app)/dashboard/setup/actions.ts, src/lib/blockchain/startupchain-client.ts

<details open><summary><h3>Security Review</h3></summary>

The contract hardening reduces several on-chain risks, but the off-chain payment path still allows same-founder tx replay because the commitment is unused. Treasury misconfiguration can also route user prepayments to the hot signer.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/contracts/src/StartupChain.sol | Adds Safe-owner registration checks, reentrancy protection, timelocked fee-recipient updates, corrected ENS node calculation, bounded founder loops, and founder indexing. |
| src/contracts/src/AttestationModule.sol | Adds Ownable2Step schema administration and gates attestations through StartupChain founder membership. |
| src/app/(app)/dashboard/setup/actions.ts | Passes founder wallets into payment verification but does not bind the payment tx to the specific registration. |
| src/app/(app)/dashboard/setup/payment-actions.ts | Verifies payment status, destination, value, and founder sender, with an optional commitment check that the live flow does not use. |
| src/lib/blockchain/startupchain-client.ts | Adds configurable treasury support but keeps a fallback to the hot signer address. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Founder
  participant Setup as commitEnsRegistrationAction
  participant Payment as checkPaymentStatusAction
  participant RPC as Sepolia RPC
  participant Treasury

  Founder->>Treasury: Send ETH payment
  Founder->>Setup: Submit registration and tx hash
  Setup->>Payment: tx hash, min value, allowed founders
  Payment->>RPC: Read receipt and transaction
  RPC-->>Payment: status, to, from, value, input
  Payment-->>Setup: confirmed when status/to/value/from pass
  Note over Payment: No commitment is supplied, so the tx is not tied to this ENS registration
  Setup-->>Founder: Continue registration
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Founder
  participant Setup as commitEnsRegistrationAction
  participant Payment as checkPaymentStatusAction
  participant RPC as Sepolia RPC
  participant Treasury

  Founder->>Treasury: Send ETH payment
  Founder->>Setup: Submit registration and tx hash
  Setup->>Payment: tx hash, min value, allowed founders
  Payment->>RPC: Read receipt and transaction
  RPC-->>Payment: status, to, from, value, input
  Payment-->>Setup: confirmed when status/to/value/from pass
  Note over Payment: No commitment is supplied, so the tx is not tied to this ENS registration
  Setup-->>Founder: Continue registration
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Security hardening: recordCompany auth, ..."](https://github.com/zenbiteth/startupchain/commit/0f5cc1bf1407198e53eb497da4641c90fb92487a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43910425)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/gerts/github/zenbiteth/startupchain/-/custom-context?memory=a0f5f3af-a437-4eb9-9e80-4de32145a538))

<!-- /greptile_comment -->